### PR TITLE
Lxd runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,9 @@ unittest:
   artifacts:
     paths:
       - report/unit
+    reports:
+        junit:
+            - report/unit/junit.xml 
 
 functional:
     stage: test
@@ -48,3 +51,9 @@ functional:
         - juju bootstrap localhost
     script:
         - JUJU_REPOSITORY=/tmp/juju make functional
+    artifacts:
+        paths:
+            - report/functional
+        reports:
+            junit:
+                - report/functional/junit.xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,28 +1,50 @@
 ---
-image: 'python:3.6'
 
 stages:
   - test
 
-before_script:
-  - python --version
-  - pip install tox
-  - mkdir -p report/lint
-  - mkdir -p report/unit
-
 flake8:
   stage: test
+  image: 'python:3.6'
+  tags:
+    - docker
+  before_script:
+    - python --version
+    - pip install tox
+    - mkdir -p report/lint
   script:
     - make lint 
   artifacts:
     paths:
       - report/lint
 
-pytest:
+unittest:
   stage: test 
+  image: 'python:3.6'
+  tags:
+    - docker
+  before_script:
+    - python --version
+    - pip install tox
+    - mkdir -p report/unit
   script:
     - make unittest
   coverage: '/^TOTAL.+?(\d+\%)$/'
   artifacts:
     paths:
       - report/unit
+
+functional:
+    stage: test
+    tags:
+        - lxd
+    before_script:
+        - git submodule sync --recursive
+        - git submodule update --init --recursive
+        - apt-get install -y tox make
+        - snap install juju --classic || true
+        - snap install juju --classic
+        - snap install charm --classic
+        - juju bootstrap localhost
+    script:
+        - JUJU_REPOSITORY=/tmp/juju make functional

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ options:
     type: string
     default: ""
     description: "The URI used when registering and communicating with the GitLab CI server"
-  concurency:
+  concurrency:
     type: int
     default: 3
     description: "Number of concurrent jobs for a runner"

--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,11 @@ options:
     type: string
     default: ""
     description: "The URI used when registering and communicating with the GitLab CI server"
+  concurency:
+    type: int
+    default: 3
+    description: "Number of concurrent jobs for a runner"
+  check-interval:
+    type: int
+    default: 0
+    description: "Seconds a runner waits between checks for each executor."

--- a/lib/libgitlabrunner.py
+++ b/lib/libgitlabrunner.py
@@ -4,7 +4,7 @@ import subprocess
 from socket import gethostname
 
 from charmhelpers.core import hookenv, templating, unitdata
-from charmhelpers.core.host import get_distrib_codename, service, add_user_to_group
+from charmhelpers.core.host import add_user_to_group, get_distrib_codename, service
 from charmhelpers.fetch import add_source, apt_install, apt_update
 
 
@@ -197,15 +197,11 @@ class GitLabRunner:
         """Set the concurrency value."""
         for line in fileinput.input(self.runner_cfg_file, inplace=True):
             if line.startswith("concurrency"):
-                print(
-                    "concurrent = {}".format(self.charm_config["concurrency"]), end=""
-                )
-            if line.startswith("check_interval"):
-                print(
-                    "check_interval = {}".format(self.charm_config["check-interval"]),
-                    end="",
-                )
-            print(line, end="")
+                print("concurrent = {}".format(self.charm_config["concurrency"]))
+            elif line.startswith("check_interval"):
+                print("check_interval = {}".format(self.charm_config["check-interval"]))
+            else:
+                print(line, end="")
 
     def unregister(self):
         """Unregister all runners."""
@@ -214,4 +210,4 @@ class GitLabRunner:
             "unregister",
             "--all-runners",
         ]
-        subprocess.check_call(command, stderr=subprocess.STDOUT)
+        subprocess.call(command, stderr=subprocess.STDOUT)

--- a/lib/libgitlabrunner.py
+++ b/lib/libgitlabrunner.py
@@ -110,6 +110,7 @@ class GitLabRunner:
     def install_docker(self):
         """Install Docker which is required for running jobs."""
         apt_install("docker.io")
+        add_user_to_group(self.gitlab_user, "docker")
         service("enable", "docker")
         service("start", "docker")
 

--- a/lib/libgitlabrunner.py
+++ b/lib/libgitlabrunner.py
@@ -198,7 +198,7 @@ class GitLabRunner:
         for line in fileinput.input(self.runner_cfg_file, inplace=True):
             if line.startswith("concurrency"):
                 print(
-                    "concurrency = {}".format(self.charm_config["concurrency"]), end=""
+                    "concurrent = {}".format(self.charm_config["concurrency"]), end=""
                 )
             if line.startswith("check_interval"):
                 print(

--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -1,3 +1,4 @@
 config:
+  raw.lxc: lxc.apparmor.profile=unconfined
   security.nesting: true
   security.privileged: true

--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -1,4 +1,4 @@
 config:
-  raw.lxc: lxc.apparmor.profile=unconfined
+  raw.lxc: "lxc.apparmor.profile=unconfined"
   security.nesting: true
   security.privileged: true

--- a/reactive/layer_gitlab_runner.py
+++ b/reactive/layer_gitlab_runner.py
@@ -22,6 +22,13 @@ def install_gitlab_runner():
     set_flag("layer-gitlab-runner.installed")
 
 
+@when_not("layer-gitlab-runner.lxd_setup")
+def setup_lxd_executor():
+    """Set up custom executor scripts for lxd executor."""
+    glr.setup_lxd()
+    set_flag("layer-gitlab-runner.lxd_setup")
+
+
 @when_not("layer-gitlab-runner.docker_installed")
 def install_docker():
     """Install docker during initial charm install as required by the GitLab Runner Docker executor."""
@@ -29,7 +36,11 @@ def install_docker():
     set_flag("layer-gitlab-runner.docker_installed")
 
 
-@when_all("layer-gitlab-runner.docker_installed", "layer-gitlab-runner.installed")
+@when_all(
+    "layer-gitlab-runner.docker_installed",
+    "layer-gitlab-runner.installed",
+    "layer-gitlab-runner.lxd_setup",
+)
 @when("config.changed")
 def configure_and_enable_gitlab_runner():
     """Upgrade, register and start the GitLab Runner and supporting services as configuration changes."""

--- a/reactive/layer_gitlab_runner.py
+++ b/reactive/layer_gitlab_runner.py
@@ -56,7 +56,10 @@ def register_runner():
     uri, token = endpoint.get_server_credentials()
     glr.gitlab_token = token
     glr.gitlab_uri = uri
+    glr.kv.set("gitlab_token", token)
+    glr.kv.set("gitlab_uri", uri)
     hookenv.log("Registering runner url/token: {}/{}".format(uri, token))
+    glr.unregister()
     glr.register()
     set_flag("runner.registered")
 
@@ -65,3 +68,6 @@ def register_runner():
 def handle_relatin_departed():
     """Handle runner relation departure."""
     clear_flag("runner.registered")
+    glr.kv.set("gitlab_token", None)
+    glr.kv.set("gitlab_uri", None)
+    glr.unregister()

--- a/reactive/layer_gitlab_runner.py
+++ b/reactive/layer_gitlab_runner.py
@@ -19,6 +19,7 @@ glr = GitLabRunner()
 def install_gitlab_runner():
     """Run upgrade helper function when GitLab Runner has not been installed previously to perform initial install."""
     glr.upgrade()
+    glr.set_global_config()
     set_flag("layer-gitlab-runner.installed")
 
 

--- a/reactive/layer_gitlab_runner.py
+++ b/reactive/layer_gitlab_runner.py
@@ -44,7 +44,7 @@ def install_docker():
 )
 @when("config.changed")
 def configure_and_enable_gitlab_runner():
-    """Upgrade, register and start the GitLab Runner and supporting services as configuration changes."""
+    """Register, configure, and start the GitLab Runner and supporting services as configuration changes."""
     glr.configure()
     glr.ensure_services()
 

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# /opt/lxd-executor/base.sh
+
+CONTAINER_ID="runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID-$CUSTOM_ENV_CI_JOB_ID"

--- a/templates/base.j2
+++ b/templates/base.j2
@@ -2,4 +2,6 @@
 
 # /opt/lxd-executor/base.sh
 
-CONTAINER_ID="runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID-$CUSTOM_ENV_CI_JOB_ID"
+CONTAINER_ID="runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID"
+# Original line with a JobID, removed to prevent build up of containers if they fail to clean
+# CONTAINER_ID="runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID-$CUSTOM_ENV_CI_JOB_ID"

--- a/templates/cleanup.j2
+++ b/templates/cleanup.j2
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# /opt/lxd-executor/cleanup.sh
+
+currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${currentDir}/base.sh # Get variables from base.
+
+echo "Deleting container $CONTAINER_ID"
+
+lxc delete -f "$CONTAINER_ID"

--- a/templates/prepare.j2
+++ b/templates/prepare.j2
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# /opt/lxd-executor/prepare.sh
+
+currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${currentDir}/base.sh # Get variables from base.
+
+set -eo pipefail
+
+# trap any error, and mark it as a system failure.
+trap "exit $SYSTEM_FAILURE_EXIT_CODE" ERR
+
+CONTAINER_ID="runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID"
+
+start_container () {
+    if lxc info "$CONTAINER_ID" >/dev/null 2>/dev/null ; then
+        echo 'Found old container, deleting'
+        lxc delete -f "$CONTAINER_ID"
+    fi
+
+    # Container image is harcoded at the moment, since Custom executor
+    # does not provide the value of `image`. See
+    # https://gitlab.com/gitlab-org/gitlab-runner/issues/4357 for
+    # details.
+    lxc launch ubuntu:18.04 "$CONTAINER_ID"
+
+    # Wait for container to start, we are using systemd to check this,
+    # for the sake of brevity.
+    for i in $(seq 1 10); do
+        if lxc exec "$CONTAINER_ID" -- sh -c "systemctl isolate multi-user.target" >/dev/null 2>/dev/null; then
+            break
+        fi
+
+        if [ "$i" == "10" ]; then
+            echo 'Waited for 10 seconds to start container, exiting..'
+            # Inform GitLab Runner that this is a system failure, so it
+            # should be retried.
+            exit "$SYSTEM_FAILURE_EXIT_CODE"
+        fi
+
+        sleep 1s
+    done
+}
+
+install_dependencies () {
+    # Install Git LFS, git comes pre installed with ubuntu image.
+    lxc exec "$CONTAINER_ID" -- sh -c "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash"
+    lxc exec "$CONTAINER_ID" -- sh -c "apt-get install git-lfs"
+
+    # Install gitlab-runner binary since we need for cache/artifacts.
+    lxc exec "$CONTAINER_ID" -- sh -c "curl -L --output /usr/local/bin/gitlab-runner https://gitlab-runner-downloads.s3.amazonaws.com/latest/binaries/gitlab-runner-linux-amd64"
+    lxc exec "$CONTAINER_ID" -- sh -c "chmod +x /usr/local/bin/gitlab-runner"
+}
+
+echo "Running in $CONTAINER_ID"
+
+start_container
+
+install_dependencies

--- a/templates/prepare.j2
+++ b/templates/prepare.j2
@@ -10,8 +10,6 @@ set -eo pipefail
 # trap any error, and mark it as a system failure.
 trap "exit $SYSTEM_FAILURE_EXIT_CODE" ERR
 
-CONTAINER_ID="runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID"
-
 start_container () {
     if lxc info "$CONTAINER_ID" >/dev/null 2>/dev/null ; then
         echo 'Found old container, deleting'
@@ -22,7 +20,7 @@ start_container () {
     # does not provide the value of `image`. See
     # https://gitlab.com/gitlab-org/gitlab-runner/issues/4357 for
     # details.
-    lxc launch ubuntu:18.04 "$CONTAINER_ID"
+    lxc launch ubuntu:18.04 "$CONTAINER_ID" -c security.nesting=true -c security.privileged=true -c raw.lxc="lxc.apparmor.profile=unconfined"
 
     # Wait for container to start, we are using systemd to check this,
     # for the sake of brevity.

--- a/templates/run.j2
+++ b/templates/run.j2
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# /opt/lxd-executor/run.sh
+
+currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${currentDir}/base.sh # Get variables from base.
+
+lxc exec "$CONTAINER_ID" /bin/bash < "${1}"
+if [ $? -ne 0 ]; then
+    # Exit using the variable, to make the build as failure in GitLab
+    # CI.
+    exit $BUILD_FAILURE_EXIT_CODE
+fi

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -60,7 +60,7 @@ async def test_gitlabrunner_deploy(model, series, source, request):
     subprocess.check_call(cmd)
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(90)
 @pytest.mark.deploy
 async def test_gitlab_deploy(model):
     """Deploy gitlab bundle."""
@@ -99,7 +99,7 @@ async def test_charm_upgrade(model, app):
 
 
 # Tests
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(900)
 async def test_gitlabrunner_status(model, app):
     """Verify status of deployed unit."""
     # Verifies status for all deployed series of the charm
@@ -140,7 +140,7 @@ async def test_file_stat(app, jujutools):
     assert fstat.st_gid == 0
 
 
-@pytest.mark.timeout(420)
+@pytest.mark.timeout(900)
 async def test_gitlab_status(model):
     """Verify status of supporting deploy."""
     # Verifies status of the gitlab deploy to test against
@@ -158,7 +158,7 @@ async def test_gitlab_status(model):
 
 
 @pytest.mark.relate
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 async def test_add_relation(model, app):
     """Verify the runner relation completes."""
     gitlab = model.applications["gitlab"]

--- a/tests/unit/config.toml
+++ b/tests/unit/config.toml
@@ -1,0 +1,2 @@
+concurrent = 0
+check_interval = 10

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,7 @@ import mock
 
 import pytest
 
+from charmhelpers.core import unitdata
 
 # If layer options are used, add this to layergitlabrunner
 # and import layer in libgitlabrunner
@@ -94,6 +95,7 @@ def mock_apt_update(monkeypatch):
 @pytest.fixture
 def mock_add_source(monkeypatch):
     """Mock the charmhelpers fetch add_source method."""
+
     def print_add_source(line, key):
         print("Mocked add source: {} ({})".format(line, key))
         return True
@@ -108,13 +110,16 @@ def mock_add_source(monkeypatch):
 def mock_get_distrib_codename(monkeypatch):
     """Mock the distribution codename as returned by get_destrib_codename."""
     mocked_get_distrib_codename = mock.Mock(returnvalue="bionic")
-    monkeypatch.setattr("libgitlabrunner.get_distrib_codename", mocked_get_distrib_codename)
+    monkeypatch.setattr(
+        "libgitlabrunner.get_distrib_codename", mocked_get_distrib_codename
+    )
     return mocked_get_distrib_codename
 
 
 @pytest.fixture
 def mock_check_call(monkeypatch):
     """Mock check_call to mock process executions."""
+
     def print_check_call(args, *, kwargs={}):
         print(args)
         return True
@@ -136,9 +141,8 @@ def mock_log(monkeypatch):
 @pytest.fixture
 def mock_gethostname(monkeypatch):
     """Mock gethostname to return consistent hostnames during testing."""
-    mocked_gethostname = mock.Mock(returnvalue='mocked-hostname')
-    monkeypatch.setattr("libgitlabrunner.gethostname",
-                        mocked_gethostname)
+    mocked_gethostname = mock.Mock(returnvalue="mocked-hostname")
+    monkeypatch.setattr("libgitlabrunner.gethostname", mocked_gethostname)
     return mocked_gethostname
 
 
@@ -159,7 +163,22 @@ def mock_action_fail(monkeypatch):
 
 
 @pytest.fixture
-def gitlabrunner(tmpdir, mock_hookenv_config, mock_charm_dir, mock_template, monkeypatch):
+def mock_unit_db(monkeypatch):
+    """Mock the key value store."""
+    mock_kv = mock.Mock()
+    mock_kv.return_value = unitdata.Storage(path=":memory:")
+    monkeypatch.setattr("libgitlabrunner.unitdata.kv", mock_kv)
+
+
+@pytest.fixture
+def gitlabrunner(
+    tmpdir,
+    mock_hookenv_config,
+    mock_charm_dir,
+    mock_template,
+    mock_unit_db,
+    monkeypatch,
+):
     """Mock the GitLab runner helper module used throughout the charm."""
     from libgitlabrunner import GitLabRunner
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,10 +1,12 @@
 #!/usr/bin/python3
 """Provide test fixtures for unit tests."""
+
+from charmhelpers.core import unitdata
+
 import mock
 
 import pytest
 
-from charmhelpers.core import unitdata
 
 # If layer options are used, add this to layergitlabrunner
 # and import layer in libgitlabrunner

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -66,6 +66,12 @@ def mock_template(monkeypatch):
     monkeypatch.setattr("libgitlabrunner.templating.host.os.fchown", mock.Mock())
     monkeypatch.setattr("libgitlabrunner.templating.host.os.chown", mock.Mock())
     monkeypatch.setattr("libgitlabrunner.templating.host.os.fchmod", mock.Mock())
+    mock_getpwname = mock.Mock()
+    mock_pw_uid = mock.Mock()
+    mock_pw_uid.return_value = '1000'
+    mock_getpwname.pw_uid = mock_pw_uid
+    monkeypatch.setattr("libgitlabrunner.templating.host.pwd.getpwnam", mock_getpwname)
+    monkeypatch.setattr("libgitlabrunner.templating.host.grp.getgrnam", mock_getpwname)
 
 
 @pytest.fixture
@@ -177,6 +183,7 @@ def gitlabrunner(
     mock_charm_dir,
     mock_template,
     mock_unit_db,
+    mock_check_call,
     monkeypatch,
 ):
     """Mock the GitLab runner helper module used throughout the charm."""
@@ -188,10 +195,10 @@ def gitlabrunner(
     glr.executor_dir = executor_dir
 
     # Example config file patching
-    cfg_file = tmpdir.join("example.cfg")
-    with open("./tests/unit/example.cfg", "r") as src_file:
+    cfg_file = tmpdir.join("config.toml")
+    with open("./tests/unit/config.toml", "r") as src_file:
         cfg_file.write(src_file.read())
-    glr.example_config_file = cfg_file.strpath
+    glr.runner_cfg_file = cfg_file.strpath
 
     # Any other functions that load helper will get this version
     monkeypatch.setattr("libgitlabrunner.GitLabRunner", lambda: glr)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,7 +56,15 @@ def mock_remote_unit(monkeypatch):
 @pytest.fixture
 def mock_charm_dir(monkeypatch):
     """Mock the charm directory location."""
-    monkeypatch.setattr("libgitlabrunner.hookenv.charm_dir", lambda: "/mock/charm/dir")
+    monkeypatch.setattr("libgitlabrunner.hookenv.charm_dir", lambda: ".")
+
+
+@pytest.fixture
+def mock_template(monkeypatch):
+    """Mock template library."""
+    monkeypatch.setattr("libgitlabrunner.templating.host.os.fchown", mock.Mock())
+    monkeypatch.setattr("libgitlabrunner.templating.host.os.chown", mock.Mock())
+    monkeypatch.setattr("libgitlabrunner.templating.host.os.fchmod", mock.Mock())
 
 
 @pytest.fixture
@@ -151,11 +159,14 @@ def mock_action_fail(monkeypatch):
 
 
 @pytest.fixture
-def gitlabrunner(tmpdir, mock_hookenv_config, mock_charm_dir, monkeypatch):
+def gitlabrunner(tmpdir, mock_hookenv_config, mock_charm_dir, mock_template, monkeypatch):
     """Mock the GitLab runner helper module used throughout the charm."""
     from libgitlabrunner import GitLabRunner
 
     glr = GitLabRunner()
+
+    executor_dir = tmpdir
+    glr.executor_dir = executor_dir
 
     # Example config file patching
     cfg_file = tmpdir.join("example.cfg")

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -29,25 +29,6 @@ def test_upgrade(
     mock_apt_install.assert_called_once()
 
 
-def test_ensure_services(gitlabrunner, mock_service):
-    """Test the ensure_services function of the helper module."""
-    gitlabrunner.ensure_services()
-    assert mock_service.call_count == 0
-    gitlabrunner.kv.set("registered", True)
-    gitlabrunner.ensure_services()
-    assert mock_service.call_count == 4
-    mock_service.assert_has_calls(
-        [
-            call("enable", "docker"),
-            call("start", "docker"),
-            call("enable", "gitlab-runner"),
-            call("start", "gitlab-runner"),
-        ],
-        any_order=True,
-    )
-    gitlabrunner.kv.set("registered", False)
-
-
 def test_configure(
     gitlabrunner,
     mock_get_distrib_codename,

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -95,7 +95,7 @@ def test_configure(
         "--name",
         "mocked-hostname-lxd",
         "--tag-list",
-        "juju",
+        "lxd",
         "--executor",
         "custom",
         "--builds-dir",

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -22,6 +22,7 @@ def test_upgrade(
     mock_apt_update,
     mock_get_distrib_codename,
     mock_add_source,
+    mock_service,
 ):
     """Test the upgrade function."""
     gitlabrunner.upgrade()

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -29,19 +29,19 @@ def test_upgrade(
     mock_apt_install.assert_called_once()
 
 
-def test_configure(
+def test_register(
     gitlabrunner,
     mock_get_distrib_codename,
     mock_check_call,
     mock_add_source,
 ):
     """Test the configure method called when the charm configured GitLab runner."""
-    gitlabrunner.configure()
+    gitlabrunner.register()
     assert mock_check_call.call_count == 0
     gitlabrunner.gitlab_uri = "mocked-uri"
     gitlabrunner.gitlab_token = "mocked-token"
     gitlabrunner.hostname = "mocked-hostname"
-    gitlabrunner.configure()
+    gitlabrunner.register()
     test_docker = [
         "/usr/bin/gitlab-runner",
         "register",

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -126,3 +126,13 @@ def test_setup_lxd(gitlabrunner, mock_check_call):
         contents = basefile.read()
         assert "# /opt/lxd-executor/cleanup.sh" in contents
     assert mock_check_call.call_count == 2
+
+
+def test_set_global_config(gitlabrunner):
+    """Test the set_global_config function."""
+    gitlabrunner.set_global_config()
+    print(gitlabrunner.runner_cfg_file)
+    with open(gitlabrunner.runner_cfg_file, "r") as cfgfile:
+        contents = cfgfile.read()
+        assert "concurrent = 3\n" in contents
+        assert "check_interval = 0\n" in contents


### PR DESCRIPTION
Adds a custom executor that uses LXD. The LXD executor executes jobs in an 18.04 container and removes restrictions to allow nested LXD as well. Each job gets a new container and the container is removed after the run completes.
 * Tag new executor as 'lxd'
 * Remove 'juju' tag from docker
 * Rename executors for a -lxd and -docker version
 * Add options to configure concurrent and check_interval
  * Update concurrent to a default of 3

This is a large change, so I've done some extra manual testing around upgrades and functionality. Both a fresh install and an upgrade from an existing (registered via relation) runner install correctly. Existing runners will be deregistered and the new runners registered under their new names.

I've also verified this has all the settings in place to run functional testing on the local provider. I'll push an example pipeline config that bootstraps juju and runs the functional testing.

The upgrade requires one manual step that I couldn't work around for functional testing. The apparmor profile is removed in the lxd profile but before nested containers can install snaps the node has to be rebooted to pickup the new apparmor setting. It's a one time reboot but I wasn't confident I could schedule a reboot on charm upgrade in a reasonable way to it's left to the operator.