### PR TITLE
update apt_key on charm upgrade, fix unit test

### DIFF
--- a/lib/libgitlabrunner.py
+++ b/lib/libgitlabrunner.py
@@ -21,6 +21,7 @@ class GitLabRunner:
         self.executor_dir = "/opt/lxd-executor"
         self.gitlab_user = "gitlab-runner"
         self.runner_cfg_file = "/etc/gitlab-runner/config.toml"
+        self.apt_key = "3F01618A51312F3F"
         if self.charm_config["gitlab-token"]:
             self.gitlab_token = self.charm_config["gitlab-token"]
         else:
@@ -95,7 +96,7 @@ class GitLabRunner:
         # https://packages.gitlab.com/runner/gitlab-runner/gpgkey
         # https://packages.gitlab.com/runner/gitlab-runner/ubuntu/ bionic main
         distro = get_distrib_codename()
-        apt_key = "3F01618A51312F3F"
+        apt_key = self.apt_key
         apt_line = "deb https://packages.gitlab.com/runner/gitlab-runner/ubuntu/ {} main".format(
             distro
         )
@@ -105,6 +106,7 @@ class GitLabRunner:
             )
         )
         add_source(apt_line, apt_key)
+        self.kv.set('apt_key', apt_key)
         return True
 
     def install_docker(self):

--- a/reactive/layer_gitlab_runner.py
+++ b/reactive/layer_gitlab_runner.py
@@ -7,11 +7,18 @@ from charms.reactive import (
     set_flag,
     when,
     when_not,
+    hook,
 )
 
 from libgitlabrunner import GitLabRunner
 
 glr = GitLabRunner()
+
+
+@hook('upgrade-charm')
+def handle_upgrade():
+    if not glr.kv.get('apt_key') == glr.apt_key:
+        glr.add_source()
 
 
 @when_not("layer-gitlab-runner.installed")

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -2,7 +2,7 @@ flake8
 juju
 mock
 pytest
-pytest-asyncio
+pytest-asyncio<0.11.0
 pytest-html
 pytest-timeout
 requests

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -37,7 +37,7 @@ async def app(model, series, source):
     return await model._wait_for_new("application", app_name)
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(45)
 @pytest.mark.deploy
 async def test_gitlabrunner_deploy(model, series, source, request):
     """Deploy gitlab-runner."""
@@ -158,7 +158,7 @@ async def test_gitlab_status(model):
 
 
 @pytest.mark.relate
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(240)
 async def test_add_relation(model, app):
     """Verify the runner relation completes."""
     gitlab = model.applications["gitlab"]


### PR DESCRIPTION
Unfortunately, I don't think i can test the upgrade because you can't install with the old key anymore. It's fairly straight forward. Testing of install passes now.